### PR TITLE
Add sample docker container for dev database

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A collaborative bar review platform where users can create and share reviews of 
 ### Prerequisites
 
 - Node.js (v18 or higher)
-- MongoDB instance
+- MongoDB instance (see [db/README.md](db/README.md) for docker setup)
 - Environment variables configured (MONGO_URI)
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ npm install
 yarn install
 ```
 
-2. Start the development server:
+2. Optional: start a local MongoDB with Docker from repo root:
+
+```bash
+npm run db:all
+```
+
+More DB commands and demo credentials are documented in [db/README.md](db/README.md).
+
+3. Start the development server:
 
 ```bash
 npm run dev
@@ -28,7 +36,7 @@ npm run dev
 npm run dev -- --open
 ```
 
-3. Build for production:
+4. Build for production:
 
 ```bash
 npm run build

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,4 @@
+FROM mongo:7
+
+COPY init.js /docker-entrypoint-initdb.d/
+

--- a/db/Makefile
+++ b/db/Makefile
@@ -1,0 +1,31 @@
+IMAGE_NAME = enstorstark-mongo
+CONTAINER_NAME = enstorstark-mongodb
+VOLUME_NAME = enstorstark-mongodb-data
+
+.PHONY: all
+all: clean build run prepare
+
+.PHONY: build
+build: init.js
+	docker build -t $(IMAGE_NAME) .
+
+.PHONY: run
+run: build
+	-docker rm -f $(CONTAINER_NAME) || true
+	docker run -d \
+		--name $(CONTAINER_NAME) \
+		-p 27017:27017 \
+		$(IMAGE_NAME)
+		# -v $(VOLUME_NAME):/data/db \
+		# -e MONGO_INITDB_ROOT_USERNAME=root \
+		# -e MONGO_INITDB_ROOT_PASSWORD=rootpassword \
+
+.PHONY: prepare
+prepare:
+	npm run create-user admin administrator
+
+.PHONY: clean
+clean:
+	-docker rm -f $(CONTAINER_NAME) || true
+	-docker rmi $(IMAGE_NAME) || true
+	-docker volume rm $(VOLUME_NAME) || true

--- a/db/Makefile
+++ b/db/Makefile
@@ -3,7 +3,7 @@ CONTAINER_NAME = enstorstark-mongodb
 VOLUME_NAME = enstorstark-mongodb-data
 
 .PHONY: all
-all: clean build run prepare
+all: run prepare
 
 .PHONY: build
 build: init.js
@@ -15,17 +15,21 @@ run: build
 	docker run -d \
 		--name $(CONTAINER_NAME) \
 		-p 27017:27017 \
+		-v $(VOLUME_NAME):/data/db \
 		$(IMAGE_NAME)
-		# -v $(VOLUME_NAME):/data/db \
-		# -e MONGO_INITDB_ROOT_USERNAME=root \
-		# -e MONGO_INITDB_ROOT_PASSWORD=rootpassword \
 
 .PHONY: prepare
 prepare:
-	npm run create-user admin administrator
+	npm --prefix .. run create-user -- admin administrator
+
+.PHONY: stop
+stop:
+	-docker rm -f $(CONTAINER_NAME) || true
 
 .PHONY: clean
-clean:
-	-docker rm -f $(CONTAINER_NAME) || true
+clean: stop
 	-docker rmi $(IMAGE_NAME) || true
+
+.PHONY: reset
+reset: clean
 	-docker volume rm $(VOLUME_NAME) || true

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,9 @@
+# Simple docker setup for development MongoDB
+
+To ease the setup for a MongoDB instance for development purposes this can be used for a simple DB. The included Makefile will build and start a mongodb container listening on port `27017`. This can be done by running `make all`.
+
+The `init.js` is placed in `/docker-entrypoint-initdb.d/` which as can be seen here: [https://hub.docker.com/\_/mongo#environment-variables](https://hub.docker.com/_/mongo#environment-variables) will run on startup. This can be used to create some sample users but the `prepare` also does that with the `npm run create-user <user> <password>`.
+
+## Dockerfile
+The `Dockerfile` is only copying the `init.js` to the entrypoint and the rest is taken from the official mongo-image.
+

--- a/db/README.md
+++ b/db/README.md
@@ -1,9 +1,44 @@
-# Simple docker setup for development MongoDB
+# Simple Docker setup for development MongoDB
 
-To ease the setup for a MongoDB instance for development purposes this can be used for a simple DB. The included Makefile will build and start a mongodb container listening on port `27017`. This can be done by running `make all`.
+This folder contains a small MongoDB Docker setup for local development.
 
-The `init.js` is placed in `/docker-entrypoint-initdb.d/` which as can be seen here: [https://hub.docker.com/\_/mongo#environment-variables](https://hub.docker.com/_/mongo#environment-variables) will run on startup. This can be used to create some sample users but the `prepare` also does that with the `npm run create-user <user> <password>`.
+## Run from repo root
+
+The easiest way is to run the npm scripts from the repository root:
+
+```bash
+npm run db:all
+```
+
+Available commands:
+
+- `npm run db:build` - build MongoDB image
+- `npm run db:run` - run container with persistent volume
+- `npm run db:prepare` - create `admin` user with password `administrator`
+- `npm run db:all` - run + prepare
+- `npm run db:clean` - stop container and remove image
+- `npm run db:reset` - clean + delete persistent volume
+
+The underlying Makefile still exists in this folder and can also be called directly.
+
+## Persistence behavior
+
+Container data is stored in a Docker volume: `enstorstark-mongodb-data`.
+
+- Use `db:clean` if you want to keep database data.
+- Use `db:reset` if you want a full wipe and fresh initialization.
+
+## Demo users from init.js
+
+`init.js` is copied to `/docker-entrypoint-initdb.d/` and is executed by MongoDB's entrypoint on first initialization of a fresh data directory.
+
+Seeded demo users:
+
+- `dj` / `jaeger123`
+- `test` / `testpass123`
+
+These passwords are development-only and are stored as Argon2 hashes in the database.
 
 ## Dockerfile
-The `Dockerfile` is only copying the `init.js` to the entrypoint and the rest is taken from the official mongo-image.
 
+The Dockerfile only copies `init.js` into the Mongo image startup folder and otherwise uses the official `mongo:7` image.

--- a/db/init.js
+++ b/db/init.js
@@ -1,0 +1,7 @@
+db = db.getSiblingDB('enstorstark');
+
+db.users.insertMany([
+  { _id: new ObjectId(), username: "DJ", password: "jaeger"},
+  { _id: new ObjectId(), username: "Test", password: "abc"},
+]);
+

--- a/db/init.js
+++ b/db/init.js
@@ -1,7 +1,16 @@
 db = db.getSiblingDB('enstorstark');
 
 db.users.insertMany([
-  { _id: new ObjectId(), username: "DJ", password: "jaeger"},
-  { _id: new ObjectId(), username: "Test", password: "abc"},
+	{
+		_id: new ObjectId(),
+		username: 'dj',
+		password:
+			'$argon2id$v=19$m=19456,t=2,p=1$bxHFrOX1OxWF0zv++6OaSA$5egXAd5SWEDcV9GlH90rOrH201pQbosxDP6nQna5VY0'
+	},
+	{
+		_id: new ObjectId(),
+		username: 'test',
+		password:
+			'$argon2id$v=19$m=19456,t=2,p=1$Bx5ckNQgao0YLGmeONBYjg$FA3QmvO8WhbH77mFvu69lftMX7kvZyKUOqDAdnx7Dis'
+	}
 ]);
-

--- a/package.json
+++ b/package.json
@@ -12,7 +12,13 @@
 		"format": "prettier --write .",
 		"test:integration": "yarn playwright test",
 		"test:unit": "vitest",
-		"create-user": "node scripts/create-user.js"
+		"create-user": "node scripts/create-user.js",
+		"db:build": "make -C db build",
+		"db:run": "make -C db run",
+		"db:prepare": "make -C db prepare",
+		"db:all": "make -C db all",
+		"db:clean": "make -C db clean",
+		"db:reset": "make -C db reset"
 	},
 	"devDependencies": {
 		"@fontsource/fira-mono": "^5.0.0",


### PR DESCRIPTION
To ease the hassle in getting started with a mongodb we could containerize it and include some initial users in the startup! The new folder `db/` contains a Makefile to build and run MongoDB in a docker container.

Please advice :D