### PR TITLE
Consider moving docker entrypoint to build-time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,14 @@ COPY --chown=node:node package.json package-lock.json ./
 COPY --chown=node:node --from=build /app/node_modules ./node_modules
 COPY --chown=node:node --from=build /app/build ./build
 COPY --chown=node:node --from=build /app/scripts ./scripts
-COPY docker-entrypoint.sh ./docker-entrypoint.sh
 
 RUN mkdir -p uploads/images \
-	&& chown -R node:node /app \
-	&& chmod +x /app/docker-entrypoint.sh
+	&& mkdir -p /app/uploads/images \
+	&& chown -R node:node /app
 
 EXPOSE 3000
 
-ENTRYPOINT ["/app/docker-entrypoint.sh"]
+USER node
+
+ENTRYPOINT ["node", "build"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,11 @@ COPY --chown=node:node --from=build /app/node_modules ./node_modules
 COPY --chown=node:node --from=build /app/build ./build
 COPY --chown=node:node --from=build /app/scripts ./scripts
 
-RUN mkdir -p uploads/images \
-	&& mkdir -p /app/uploads/images \
+RUN mkdir -p /app/uploads/images \
 	&& chown -R node:node /app
 
 EXPOSE 3000
 
 USER node
 
-ENTRYPOINT ["node", "build"]
-
+CMD ["node", "build"]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Then edit `.env` and set at minimum:
 - `MONGO_ROOT_PASSWORD`
 - `APP_MONGO_URI` (should include `authSource=admin`)
 
-The app build also needs `MONGO_URI` at image build time, so the compose file forwards `APP_MONGO_URI` into the build args as well as runtime env.
+The app build also needs `MONGO_URI` to exist at image build time, but it does not need live production credentials. The compose file uses a non-secret placeholder build arg and passes the real connection string only as runtime env.
 
 The compose file also pins stable container names for the app and MongoDB so the reverse proxy and maintenance commands do not change when the Compose project name changes.
 
@@ -74,7 +74,7 @@ If you are wiring this app to a separate Caddy stack, attach the app to the shar
 
 The site also includes a minimal Google Analytics consent banner. It uses Google Consent Mode, so visits can still be measured in a limited way.
 
-The app container starts as root only long enough to fix permissions on the image volume, then it runs the SvelteKit server as the non-root `node` user.
+The app image prepares the upload directory during image build and runs the SvelteKit server directly as the non-root `node` user.
 
 `TRUST_PROXY` is enabled in the compose stack so the app can respect forwarded client IP headers from your external proxy.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        MONGO_URI: ${APP_MONGO_URI:?APP_MONGO_URI is required}
+        MONGO_URI: mongodb://localhost:27017/enstorstark
     environment:
       HOST: 0.0.0.0
       MONGO_URI: ${APP_MONGO_URI:?APP_MONGO_URI is required}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -eu
-
-mkdir -p /app/uploads/images
-chown -R node:node /app/uploads/images
-
-exec su node -s /bin/sh -c 'cd /app && exec node build'


### PR DESCRIPTION
With the current setup things are run in a script that could be done during build-time instead to avoid a `su`. I believe this change could be considered better practice unless we really need to run a script. But if we do, perhaps it could be run as the `node` user?

What do you think @jonathan-lindqvist ? :) 

OBS: this has not been tested properly