### PR TITLE
Add Docker-only local development setup

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,22 @@
+# Dev image for docker-compose.dev.yml. Production builds from ./Dockerfile.
+#
+# Separate file rather than a stage in Dockerfile: without BuildKit, --target still
+# runs every preceding stage.
+
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+# Must run before the project .npmrc (ignore-scripts=true) is in place, or the native
+# modules argon2 and sharp skip their build step.
+COPY package.json package-lock.json ./
+RUN npm config set ignore-scripts false && npm ci
+
+# The node_modules volume is seeded from this image, so it has to be node-owned already.
+RUN chown -R node:node /app
+
+EXPOSE 5173
+
+USER node
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+# Docker-only workflow for local development; see docker-compose.dev.yml.
+
+COMPOSE ?= $(shell docker compose version >/dev/null 2>&1 && echo 'docker compose' || echo 'docker-compose')
+DEV = $(COMPOSE) -f docker-compose.dev.yml
+
+.PHONY: help
+help:
+	@echo 'make dev                 start app + database (http://localhost:5173)'
+	@echo 'make dev-down            stop the stack, keep database and dependencies'
+	@echo 'make dev-reset           stop the stack and wipe database + dependencies'
+	@echo 'make dev-reinstall       reinstall dependencies after a package.json change'
+	@echo 'make dev-logs            follow the app log'
+	@echo 'make dev-shell           open a shell in the app container'
+	@echo 'make dev-test            run the unit tests in the app container'
+	@echo 'make dev-create-user USERNAME=<name> PASSWORD=<pass>'
+
+.PHONY: dev
+dev:
+	$(DEV) up --build
+
+# The dependency volume keeps its old contents, so a package.json change needs this.
+.PHONY: dev-reinstall
+dev-reinstall:
+	$(DEV) down
+	-docker volume rm enstorstarkreview-dev_dev-node-modules
+	$(DEV) up --build
+
+.PHONY: dev-down
+dev-down:
+	$(DEV) down
+
+.PHONY: dev-reset
+dev-reset:
+	$(DEV) down -v
+
+.PHONY: dev-logs
+dev-logs:
+	$(DEV) logs -f app
+
+.PHONY: dev-shell
+dev-shell:
+	$(DEV) exec app bash
+
+.PHONY: dev-test
+dev-test:
+	$(DEV) exec app npm run test:unit -- --run
+
+.PHONY: dev-create-user
+dev-create-user:
+	@test -n '$(USERNAME)' -a -n '$(PASSWORD)' \
+		|| { echo 'Usage: make dev-create-user USERNAME=<name> PASSWORD=<pass>'; exit 1; }
+	$(DEV) exec app npm run create-user -- '$(USERNAME)' '$(PASSWORD)'

--- a/README.md
+++ b/README.md
@@ -4,47 +4,50 @@ A collaborative bar review platform where users can create and share reviews of 
 
 ## Setup
 
-### Prerequisites
+Two ways to run the app locally. Either way the site ends up on <http://localhost:5173>
+with a MongoDB seeded with demo users, so you can log in as `test` / `testpass123` right
+away.
 
-- Node.js (v18 or higher)
-- MongoDB instance (see [db/README.md](db/README.md) for docker setup)
-- Environment variables configured (MONGO_URI)
+### Everything in Docker
 
-### Installation
+Needs only Docker. No Node.js and no `.env`:
 
-1. Install dependencies:
+```bash
+make dev
+```
+
+Editing a file reloads the browser. `make dev-down` stops it, and `make help` lists the
+rest: reset the database, run the tests, open a shell, create a user.
+
+Without `make`, the command is `docker compose -f docker-compose.dev.yml up --build`.
+
+### On your machine
+
+Needs Node.js 18 or later, plus Docker for the database. The app refuses to start without
+`MONGO_URI`, so create a `.env` file first (it is gitignored):
+
+```
+MONGO_URI=mongodb://localhost:27017/enstorstark
+```
+
+Then:
 
 ```bash
 npm install
-# or
-yarn install
-```
-
-2. Optional: start a local MongoDB with Docker from repo root:
-
-```bash
-npm run db:all
-```
-
-More DB commands and demo credentials are documented in [db/README.md](db/README.md).
-
-3. Start the development server:
-
-```bash
+npm run db:all   # MongoDB in Docker, seeded with the demo users
 npm run dev
-# or to open in browser automatically
-npm run dev -- --open
 ```
 
-4. Build for production:
-
-```bash
-npm run build
-```
+`npm run dev -- --open` opens a browser, `npm run build` makes a production build, and
+[db/README.md](db/README.md) has the other database commands.
 
 ## Deployment with Docker
 
 The repository includes a production app image and a MongoDB container based on `db/Dockerfile`.
+
+`docker-compose.yml` is for deployment only: it expects secrets in `.env`, publishes no
+ports, and attaches to an external reverse proxy network. To run the app locally, use
+`make dev` from [Setup](#setup) instead.
 
 Before first start, create a `.env` file from `.env.example` and set strong credentials:
 

--- a/db/README.md
+++ b/db/README.md
@@ -2,6 +2,10 @@
 
 This folder contains a small MongoDB Docker setup for local development.
 
+`make dev` in the repository root already starts this database together with the app, and
+needs no Node.js on the host. The commands below are for running only the database, with
+the app started separately through npm.
+
 ## Run from repo root
 
 The easiest way is to run the npm scripts from the repository root:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,45 @@
+# Local development stack. Usage is in the README; deployment uses docker-compose.yml.
+
+name: enstorstarkreview-dev
+
+services:
+  app:
+    container_name: enstorstarkreview-dev-app
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    environment:
+      MONGO_URI: mongodb://mongo:27017/enstorstark
+      NODE_ENV: development
+      # Bind mounts do not forward file system events, so Vite has to poll.
+      VITE_DEV_POLLING: 'true'
+    depends_on:
+      mongo:
+        condition: service_healthy
+    ports:
+      - '5173:5173'
+    volumes:
+      - .:/app
+      # Shadows the bind mount so the container keeps its own Linux-built
+      # node_modules; argon2 and sharp are native.
+      - dev-node-modules:/app/node_modules
+
+  mongo:
+    container_name: enstorstarkreview-dev-mongo
+    build:
+      context: ./db
+    # Unauthenticated by design; db/init.js seeds the demo users on first start.
+    ports:
+      - '27017:27017'
+    volumes:
+      - dev-mongo-data:/data/db
+    healthcheck:
+      test: ['CMD-SHELL', 'mongosh --quiet --eval "db.adminCommand({ ping: 1 }).ok"']
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+volumes:
+  dev-node-modules:
+  dev-mongo-data:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,10 @@ const nativeExternals = ['argon2'];
 
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
+	server: {
+		// Docker bind mounts deliver no file system events; only dev containers set this.
+		watch: process.env.VITE_DEV_POLLING === 'true' ? { usePolling: true, interval: 300 } : undefined
+	},
 	ssr: {
 		external: nativeExternals
 	},


### PR DESCRIPTION
Running the app locally previously required Node.js on the host, and the existing compose file is deployment-only: it expects secrets in .env, publishes no ports, and attaches to an external proxy network.

Adds docker-compose.dev.yml and Dockerfile.dev so that `make dev` starts the dev server plus a seeded MongoDB in containers, with no host toolchain and no .env. Vite watches through polling because Docker bind mounts do not forward file system events. The dev image is a separate file rather than a stage in Dockerfile because builds without BuildKit run every preceding stage even when --target is given.

Also rewrites the README start for both paths. The manual steps could not work as written: the app throws without MONGO_URI, but no step set it.